### PR TITLE
WP-73: Github  old PRs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,6 +18,7 @@ pipeline {
           currentBuild.description = "Teambot run for the day"
         }
         checkout scm
+        sh 'pip3 install -r requirements.txt'
       }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,6 +23,9 @@ pipeline {
     }
 
     stage ('Run') {
+      environment {
+        GITHUB_CREDS = credentials('github-jenkins-wazo-bot')
+      }
       steps {
         sh 'python3 ./agenda.py planning.yaml "$MATTERMOST_HOOK_URL" dev-daily-scrum'
       }

--- a/agenda.py
+++ b/agenda.py
@@ -11,8 +11,8 @@ from datetime import timedelta, datetime
 GITHUB_SEARCH_QUERY = r'is:open is:pr archived:false user:wazo-platform user:TinxHQ user:wazo-communication sort:updated-asc label:mergeit'
 MAX_SEARCH = 10
 
-GITHUB_USER = os.environ.get('GITHUB_CREDS_USR')
-GITHUB_PASSWORD = os.environ.get('GITHUB_CREDS_PSW')
+GITHUB_USER = os.getenv('GITHUB_CREDS_USR')
+GITHUB_PASSWORD = os.getenv('GITHUB_CREDS_PSW')
 
 
 def send_message(url, message, channel=None):

--- a/agenda.py
+++ b/agenda.py
@@ -47,18 +47,28 @@ def compute_message(today, conf):
                     else message_lines
                 )
                 list_to_append.append(new_date.strftime(recurring_msg['text']))
+
+        if data.get('github_old_prs'):
+            message_lines.append(find_old_github_prs())
+
     message_lines = before_message_lines + message_lines
     if message_lines:
         return "\n".join(message_lines)
     return None
 
 
+def get_github_prs(github, search_query):
+    return [
+        result.issue.pull_request()
+        for result in github.search_issues(search_query, number=MAX_SEARCH)
+    ]
+
+
 def find_old_github_prs():
-    gh = github3.GitHub()
-    search_results = gh.search_issues(GITHUB_SEARCH_QUERY, number=MAX_SEARCH)
+    github = github3.GitHub()
+    prs = get_github_prs(github, GITHUB_SEARCH_QUERY)
     old_prs = []
-    for result in search_results:
-        pr = result.issue.pull_request()
+    for pr in prs:
         updated = pr.updated_at
         age = (datetime.now() - updated).days
         line = f'- **{age} days**: [{pr.title} ({pr.repository.fullname}#{pr.number})]({pr.html_url})'

--- a/agenda.py
+++ b/agenda.py
@@ -78,18 +78,23 @@ def get_github_prs(github, search_query):
     ]
 
 
-def find_old_github_prs(day_threshold):
-    github = github3.GitHub(GITHUB_USER, GITHUB_PASSWORD)
-    mtl_time = pytz.timezone('America/Montreal')
-    time_now_mtl = mtl_time.localize(datetime.now())
-    search_date = time_now_mtl - timedelta(days=day_threshold)
+def generate_github_query_params(now_time, day_threshold):
+    search_date = now_time - timedelta(days=day_threshold)
     search_date_iso = search_date.isoformat()
     query = GITHUB_SEARCH_QUERY_PARTS + [f'updated:<{search_date_iso}']
-    prs = get_github_prs(github, ' '.join(query))
+    return ' '.join(query)
+
+
+def find_old_github_prs(day_threshold):
+    github = github3.GitHub(GITHUB_USER, GITHUB_PASSWORD)
+    mtl_tz = pytz.timezone('America/Montreal')
+    mtl_time = mtl_tz.localize(datetime.now())
+    query_params = generate_github_query_params(mtl_time, day_threshold)
+    prs = get_github_prs(github, query_params)
     old_prs = []
     for pr in prs:
         updated = pr.updated_at
-        age = (time_now_mtl - updated).days
+        age = (mtl_time - updated).days
         line = f'- **{age} days**: [{pr.title} ({pr.repository.full_name}#{pr.number})]({pr.html_url})'
         old_prs.append(line)
     if not old_prs:

--- a/agenda.py
+++ b/agenda.py
@@ -84,7 +84,7 @@ def find_old_github_prs(day_threshold):
     time_now_mtl = mtl_time.localize(datetime.now())
     search_date = time_now_mtl - timedelta(days=day_threshold)
     search_date_iso = search_date.isoformat()
-    query = GITHUB_SEARCH_QUERY_PARTS + [f'updated:<={search_date_iso}']
+    query = GITHUB_SEARCH_QUERY_PARTS + [f'updated:<{search_date_iso}']
     prs = get_github_prs(github, ' '.join(query))
     old_prs = []
     for pr in prs:

--- a/agenda.py
+++ b/agenda.py
@@ -16,7 +16,7 @@ GITHUB_SEARCH_QUERY_PARTS = [
     'user:wazo-platform',
     'user:TinxHQ',
     'user:wazo-communication',
-    'sort:updated-desc',
+    'sort:updated-asc',
     'draft:false',
 ]
 MAX_SEARCH = 10

--- a/agenda.py
+++ b/agenda.py
@@ -49,7 +49,7 @@ def compute_message(today, conf):
                 list_to_append.append(new_date.strftime(recurring_msg['text']))
 
         if data.get('github_old_prs'):
-            message_lines.append(find_old_github_prs())
+            message_lines.append(find_old_github_prs(conf['old_pr_threshold']))
 
     message_lines = before_message_lines + message_lines
     if message_lines:
@@ -64,15 +64,16 @@ def get_github_prs(github, search_query):
     ]
 
 
-def find_old_github_prs():
+def find_old_github_prs(day_threshold):
     github = github3.GitHub()
     prs = get_github_prs(github, GITHUB_SEARCH_QUERY)
     old_prs = []
     for pr in prs:
         updated = pr.updated_at
         age = (datetime.now() - updated).days
-        line = f'- **{age} days**: [{pr.title} ({pr.repository.fullname}#{pr.number})]({pr.html_url})'
-        old_prs.append(line)
+        if age >= day_threshold:
+            line = f'- **{age} days**: [{pr.title} ({pr.repository.fullname}#{pr.number})]({pr.html_url})'
+            old_prs.append(line)
 
     return old_prs
 

--- a/agenda.py
+++ b/agenda.py
@@ -2,6 +2,7 @@
 
 import github3
 import os
+import pytz
 import requests
 import sys
 import yaml
@@ -79,14 +80,16 @@ def get_github_prs(github, search_query):
 
 def find_old_github_prs(day_threshold):
     github = github3.GitHub(GITHUB_USER, GITHUB_PASSWORD)
-    search_date = datetime.now() - timedelta(days=day_threshold)
+    mtl_time = pytz.timezone('America/Montreal')
+    time_now_mtl = mtl_time.localize(datetime.now())
+    search_date = time_now_mtl - timedelta(days=day_threshold)
     search_date_iso = search_date.isoformat()
     query = GITHUB_SEARCH_QUERY_PARTS + [f'updated:<={search_date_iso}']
     prs = get_github_prs(github, ' '.join(query))
     old_prs = []
     for pr in prs:
         updated = pr.updated_at
-        age = (datetime.now() - updated).days
+        age = (time_now_mtl - updated).days
         line = f'- **{age} days**: [{pr.title} ({pr.repository.fullname}#{pr.number})]({pr.html_url})'
         old_prs.append(line)
     if not old_prs:

--- a/agenda.py
+++ b/agenda.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python3
 
+import github3
 import requests
 import sys
 import yaml
 
 from datetime import timedelta, datetime
+
+GITHUB_SEARCH_QUERY = r'is:open is:pr archived:false user:wazo-platform user:TinxHQ user:wazo-communication sort:updated-asc label:mergeit'
+MAX_SEARCH = 10
 
 
 def send_message(url, message, channel=None):
@@ -47,6 +51,20 @@ def compute_message(today, conf):
     if message_lines:
         return "\n".join(message_lines)
     return None
+
+
+def find_old_github_prs():
+    gh = github3.GitHub()
+    search_results = gh.search_issues(GITHUB_SEARCH_QUERY, number=MAX_SEARCH)
+    old_prs = []
+    for result in search_results:
+        pr = result.issue.pull_request()
+        updated = pr.updated_at
+        age = (datetime.now() - updated).days
+        line = f'- **{age} days**: [{pr.title} ({pr.repository.fullname}#{pr.number})]({pr.html_url})'
+        old_prs.append(line)
+
+    return old_prs
 
 
 if __name__ == "__main__":

--- a/agenda.py
+++ b/agenda.py
@@ -12,7 +12,7 @@ GITHUB_SEARCH_QUERY = r'is:open is:pr archived:false user:wazo-platform user:Tin
 MAX_SEARCH = 10
 
 GITHUB_USER = os.environ.get('GITHUB_CREDS_USR')
-GITHUB_PASSWORD = os.environ.get('GITHUB_CREDS_PWD')
+GITHUB_PASSWORD = os.environ.get('GITHUB_CREDS_PSW')
 
 
 def send_message(url, message, channel=None):

--- a/agenda.py
+++ b/agenda.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import github3
+import os
 import requests
 import sys
 import yaml
@@ -9,6 +10,9 @@ from datetime import timedelta, datetime
 
 GITHUB_SEARCH_QUERY = r'is:open is:pr archived:false user:wazo-platform user:TinxHQ user:wazo-communication sort:updated-asc label:mergeit'
 MAX_SEARCH = 10
+
+GITHUB_USER = os.environ.get('GITHUB_CREDS_USR')
+GITHUB_PASSWORD = os.environ.get('GITHUB_CREDS_PWD')
 
 
 def send_message(url, message, channel=None):
@@ -65,7 +69,7 @@ def get_github_prs(github, search_query):
 
 
 def find_old_github_prs(day_threshold):
-    github = github3.GitHub()
+    github = github3.GitHub(GITHUB_USER, GITHUB_PASSWORD)
     prs = get_github_prs(github, GITHUB_SEARCH_QUERY)
     old_prs = []
     for pr in prs:

--- a/agenda.py
+++ b/agenda.py
@@ -17,7 +17,7 @@ GITHUB_SEARCH_QUERY_PARTS = [
     'user:TinxHQ',
     'user:wazo-communication',
     'sort:updated-desc',
-    'label:mergeit',
+    'draft:false',
 ]
 MAX_SEARCH = 10
 

--- a/agenda.py
+++ b/agenda.py
@@ -8,7 +8,7 @@ import yaml
 
 from datetime import timedelta, datetime
 
-GITHUB_SEARCH_QUERY = r'is:open is:pr archived:false user:wazo-platform user:TinxHQ user:wazo-communication sort:updated-asc label:mergeit'
+GITHUB_SEARCH_QUERY = r'is:open is:pr archived:false user:wazo-platform user:TinxHQ user:wazo-communication sort:updated-asc label:mergeit label:"🙏 Please review"'
 MAX_SEARCH = 10
 
 GITHUB_USER = os.getenv('GITHUB_CREDS_USR')
@@ -52,8 +52,8 @@ def compute_message(today, conf):
                 )
                 list_to_append.append(new_date.strftime(recurring_msg['text']))
 
-        if data.get('github_old_prs'):
-            message_lines.append(find_old_github_prs(conf['old_pr_threshold']))
+            if recurring_msg.get('github_old_prs'):
+                message_lines.extend(find_old_github_prs(conf['old_pr_threshold']))
 
     message_lines = before_message_lines + message_lines
     if message_lines:
@@ -78,7 +78,8 @@ def find_old_github_prs(day_threshold):
         if age >= day_threshold:
             line = f'- **{age} days**: [{pr.title} ({pr.repository.fullname}#{pr.number})]({pr.html_url})'
             old_prs.append(line)
-
+    if not old_prs:
+        old_prs.append('- None, congratulations!')
     return old_prs
 
 

--- a/agenda.py
+++ b/agenda.py
@@ -90,7 +90,7 @@ def find_old_github_prs(day_threshold):
     for pr in prs:
         updated = pr.updated_at
         age = (time_now_mtl - updated).days
-        line = f'- **{age} days**: [{pr.title} ({pr.repository.fullname}#{pr.number})]({pr.html_url})'
+        line = f'- **{age} days**: [{pr.title} ({pr.repository.full_name}#{pr.number})]({pr.html_url})'
         old_prs.append(line)
     if not old_prs:
         old_prs.append('- None, congratulations!')

--- a/planning.yaml
+++ b/planning.yaml
@@ -6,6 +6,8 @@ recurring_messages:
   - text: "***\n# %Y-%m-%d"
     before: true
   - text: "- [New tickets](https://wazo-dev.atlassian.net/issues/?filter=10105)"
+  - text: "## Old PRs:"
+    github_old_prs: true
 messages:
   # Friday week0
   0:

--- a/planning.yaml
+++ b/planning.yaml
@@ -1,6 +1,7 @@
 ---
 period: 21
 start: 2021-01-01
+old_pr_threshold: 4
 recurring_messages:
   - text: "***\n# %Y-%m-%d"
     before: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+github3.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 github3.py
+pytz

--- a/test_agenda.py
+++ b/test_agenda.py
@@ -4,8 +4,32 @@ import datetime
 import unittest
 
 from io import StringIO
+from unittest.mock import MagicMock, patch
 
 import agenda
+
+CONF = '''
+---
+period: 21
+start: 2020-02-21
+recurring_messages:
+  - text: "Daily note on %Y-%m-%d"
+  - text: "# %Y-%m-%d"
+    before: true
+  - text: "Another before"
+    before: true
+messages:
+  # Friday week0
+  0:
+    text: "- Planning"
+    offset: 3
+  2:
+    offset: 0
+  # Monday week1
+  3:
+    text: "- Grooming"
+    offset: 1
+'''
 
 
 class TestAgenda(unittest.TestCase):
@@ -56,29 +80,59 @@ class TestAgenda(unittest.TestCase):
             '# 2020-02-25\nAnother before\n- Grooming\nDaily note on 2020-02-25',
         )
 
+    @patch('agenda.get_github_prs')
+    def test_github_only_one_old_pr(self, github_results):
+        pr_date = datetime.datetime(2020, 2, 21, 15, 0)
+        github_results.return_value = [
+            MagicMock(
+                updated_at=pr_date,
+                title='Test PR',
+                repository=MagicMock(fullname='test/test_repo'),
+                number=42,
+                html_url='an_url',
+            ),
+        ]
+        prs = agenda.find_old_github_prs()
+        age = (datetime.datetime.now() - pr_date).days
+        expected_lines = [f'- **{age} days**: [Test PR (test/test_repo#42)](an_url)']
+        self.assertEqual(prs, expected_lines)
 
-CONF = '''
----
-period: 21
-start: 2020-02-21
-recurring_messages:
-  - text: "Daily note on %Y-%m-%d"
-  - text: "# %Y-%m-%d"
-    before: true
-  - text: "Another before"
-    before: true
-messages:
-  # Friday week0
-  0:
-    text: "- Planning"
-    offset: 3
-  2:
-    offset: 0
-  # Monday week1
-  3:
-    text: "- Grooming"
-    offset: 1
-'''
+    @patch('agenda.get_github_prs')
+    def test_github_multiple_old_prs(self, github_results):
+        pr1_date = datetime.datetime(2020, 2, 21, 15, 0)
+        pr2_date = datetime.datetime(2020, 3, 21, 15, 0)
+        github_results.return_value = [
+            MagicMock(
+                updated_at=pr1_date,
+                title='Test PR',
+                repository=MagicMock(fullname='test/test_repo'),
+                number=42,
+                html_url='an_url',
+            ),
+            MagicMock(
+                updated_at=pr2_date,
+                title='Test PR 2',
+                repository=MagicMock(fullname='test/test_repo2'),
+                number=43,
+                html_url='an_url2',
+            ),
+        ]
+        prs = agenda.find_old_github_prs()
+        pr1_age = (datetime.datetime.now() - pr1_date).days
+        pr2_age = (datetime.datetime.now() - pr2_date).days
+        expected_lines = [
+            f'- **{pr1_age} days**: [Test PR (test/test_repo#42)](an_url)',
+            f'- **{pr2_age} days**: [Test PR 2 (test/test_repo2#43)](an_url2)',
+        ]
+        self.assertEqual(prs, expected_lines)
+
+    @patch('agenda.get_github_prs')
+    def test_github_no_old_pr(self, github_results):
+        github_results.return_value = []
+        prs = agenda.find_old_github_prs()
+        expected_lines = []
+        self.assertEqual(prs, expected_lines)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test_agenda.py
+++ b/test_agenda.py
@@ -19,6 +19,8 @@ recurring_messages:
     before: true
   - text: "Another before"
     before: true
+  - text: "## Old PRs:"
+    github_old_prs: True
 messages:
   # Friday week0
   0:
@@ -50,6 +52,10 @@ class TestAgenda(unittest.TestCase):
                         'text': 'Another before',
                         'before': True,
                     },
+                    {
+                        'text': '## Old PRs:',
+                        'github_old_prs': True,
+                    },
                 ],
                 'messages': {
                     0: {'offset': 3, 'text': '- Planning'},
@@ -62,24 +68,26 @@ class TestAgenda(unittest.TestCase):
             },
         )
 
-    def test_compute_message(self):
+    @patch('agenda.get_github_prs')
+    def test_compute_message_no_old_pr(self, github_results):
         conf = agenda.load_conf(StringIO(CONF))
         now = datetime.datetime(2020, 2, 21, 17, 0)
+        github_results.return_value = []
         self.assertEqual(
             agenda.compute_message(now, conf),
-            '# 2020-02-24\nAnother before\n- Planning\nDaily note on 2020-02-24',
+            '# 2020-02-24\nAnother before\n- Planning\nDaily note on 2020-02-24\n## Old PRs:\n- None, congratulations!',
         )
         now = datetime.datetime(2020, 2, 22, 17, 0)
         self.assertEqual(agenda.compute_message(now, conf), None)
         now = datetime.datetime(2020, 2, 23, 17, 0)
         self.assertEqual(
             agenda.compute_message(now, conf),
-            '# 2020-02-23\nAnother before\nDaily note on 2020-02-23',
+            '# 2020-02-23\nAnother before\nDaily note on 2020-02-23\n## Old PRs:\n- None, congratulations!',
         )
         now = datetime.datetime(2020, 2, 24, 17, 0)
         self.assertEqual(
             agenda.compute_message(now, conf),
-            '# 2020-02-25\nAnother before\n- Grooming\nDaily note on 2020-02-25',
+            '# 2020-02-25\nAnother before\n- Grooming\nDaily note on 2020-02-25\n## Old PRs:\n- None, congratulations!',
         )
 
     @patch('agenda.get_github_prs')
@@ -128,6 +136,8 @@ class TestAgenda(unittest.TestCase):
         ]
         self.assertEqual(prs, expected_lines)
 
+
+
     @patch('agenda.get_github_prs')
     def test_github_no_old_pr(self, github_results):
         github_results.return_value = [
@@ -140,7 +150,7 @@ class TestAgenda(unittest.TestCase):
             ),
         ]
         prs = agenda.find_old_github_prs(4)
-        expected_lines = []
+        expected_lines = ['- None, congratulations!']
         self.assertEqual(prs, expected_lines)
 
 

--- a/test_agenda.py
+++ b/test_agenda.py
@@ -12,6 +12,7 @@ CONF = '''
 ---
 period: 21
 start: 2020-02-21
+old_pr_threshold: 4
 recurring_messages:
   - text: "Daily note on %Y-%m-%d"
   - text: "# %Y-%m-%d"
@@ -57,6 +58,7 @@ class TestAgenda(unittest.TestCase):
                 },
                 'period': 21,
                 'start': datetime.datetime(2020, 2, 21, 0, 0),
+                'old_pr_threshold': 4,
             },
         )
 
@@ -92,7 +94,7 @@ class TestAgenda(unittest.TestCase):
                 html_url='an_url',
             ),
         ]
-        prs = agenda.find_old_github_prs()
+        prs = agenda.find_old_github_prs(4)
         age = (datetime.datetime.now() - pr_date).days
         expected_lines = [f'- **{age} days**: [Test PR (test/test_repo#42)](an_url)']
         self.assertEqual(prs, expected_lines)
@@ -117,7 +119,7 @@ class TestAgenda(unittest.TestCase):
                 html_url='an_url2',
             ),
         ]
-        prs = agenda.find_old_github_prs()
+        prs = agenda.find_old_github_prs(4)
         pr1_age = (datetime.datetime.now() - pr1_date).days
         pr2_age = (datetime.datetime.now() - pr2_date).days
         expected_lines = [
@@ -128,8 +130,16 @@ class TestAgenda(unittest.TestCase):
 
     @patch('agenda.get_github_prs')
     def test_github_no_old_pr(self, github_results):
-        github_results.return_value = []
-        prs = agenda.find_old_github_prs()
+        github_results.return_value = [
+            MagicMock(
+                updated_at=datetime.datetime.now(),
+                title='Young PR',
+                repository=MagicMock(fullname='test/test_repo'),
+                number=44,
+                html_url='an_url3',
+            ),
+        ]
+        prs = agenda.find_old_github_prs(4)
         expected_lines = []
         self.assertEqual(prs, expected_lines)
 

--- a/test_agenda.py
+++ b/test_agenda.py
@@ -97,7 +97,7 @@ class TestAgenda(unittest.TestCase):
             MagicMock(
                 updated_at=pr_date,
                 title='Test PR',
-                repository=MagicMock(fullname='test/test_repo'),
+                repository=MagicMock(full_name='test/test_repo'),
                 number=42,
                 html_url='an_url',
             ),
@@ -115,14 +115,14 @@ class TestAgenda(unittest.TestCase):
             MagicMock(
                 updated_at=pr1_date,
                 title='Test PR',
-                repository=MagicMock(fullname='test/test_repo'),
+                repository=MagicMock(full_name='test/test_repo'),
                 number=42,
                 html_url='an_url',
             ),
             MagicMock(
                 updated_at=pr2_date,
                 title='Test PR 2',
-                repository=MagicMock(fullname='test/test_repo2'),
+                repository=MagicMock(full_name='test/test_repo2'),
                 number=43,
                 html_url='an_url2',
             ),
@@ -144,7 +144,7 @@ class TestAgenda(unittest.TestCase):
             MagicMock(
                 updated_at=datetime.datetime.now(),
                 title='Young PR',
-                repository=MagicMock(fullname='test/test_repo'),
+                repository=MagicMock(full_name='test/test_repo'),
                 number=44,
                 html_url='an_url3',
             ),


### PR DESCRIPTION
TODO:
- [x] GitHub credentials from Jenkins
      Otherwise, we are limited to the public project
- [x] Define the days on which we want the old PRs shown
- [ ] Refactor so that we can use `label:mergeit` and `label:🙏Please review` to search for PRs. 

There is a Jenkins job called `teambot-tests`that allows testing this PR.
It has been decided that we want the PRs over 4 days old, oldest first, in descending order of age