### PR TITLE
Send daily-scrum reminder into multiple channels

### DIFF
--- a/agenda.py
+++ b/agenda.py
@@ -224,7 +224,7 @@ if __name__ == "__main__":
     try:
         conf_file_path = sys.argv[1]
         mattermost_url = sys.argv[2]
-        mattermost_channel = sys.argv[3]
+        mattermost_channels = sys.argv[3:]
     except IndexError:
         print('Usage: %s <conf> <url> <chan>' % sys.argv[0], file=sys.stderr)
         sys.exit(1)
@@ -234,7 +234,8 @@ if __name__ == "__main__":
     now = datetime.now()
     message = compute_message(now, conf)
     if message:
-        print(message, mattermost_channel, file=sys.stderr)
-        send_message(mattermost_url, message, mattermost_channel)
+        for mattermost_channel in mattermost_channels:
+            print(message, mattermost_channel, file=sys.stderr)
+            send_message(mattermost_url, message, mattermost_channel)
     else:
         print('No message today', file=sys.stderr)

--- a/daily-scrum/Jenkinsfile
+++ b/daily-scrum/Jenkinsfile
@@ -1,3 +1,5 @@
+def DAILY_CHANNELS = ['team-central', 'external-visio', 'administrator-roles', 'sso---ldap'].join(' ');
+
 pipeline {
 
   agent any
@@ -27,7 +29,7 @@ pipeline {
         GITHUB_CREDS = credentials('github-jenkins-wazo-bot')
       }
       steps {
-        sh 'python3 ./agenda.py daily-scrum/planning.yaml "$MATTERMOST_HOOK_URL" dev-daily-scrum'
+        sh "python3 ./agenda.py daily-scrum/planning.yaml '$MATTERMOST_HOOK_URL' $DAILY_CHANNELS"
       }
     }
   }


### PR DESCRIPTION
- Fetch PR listing once (prevent rate-limit on Github)
- Send to multi-channels

## How to test
- Run a replay for the right pipeline in Jenkins
- Change `DAILY_CHANNELS` for testing one `patate-1, patate-2, patate-3` (They exists for real)
- Checkout this branch in the pipeline `sh 'git checkout daily-bot-multi-channels'`