### PR TITLE
jenkins: run in virtualenv

### DIFF
--- a/daily-scrum/Jenkinsfile
+++ b/daily-scrum/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
           currentBuild.description = "Teambot run for the daily scrum"
         }
         checkout scm
-        sh 'pip3 install -r requirements.txt'
+        sh "${WORKSPACE}/jenkins/prepare-virtualenv.sh ${venv}"
       }
     }
 
@@ -33,7 +33,10 @@ pipeline {
         GITHUB_CREDS = credentials('github-jenkins-wazo-bot')
       }
       steps {
-        sh "python3 ./agenda.py daily-scrum/planning.yaml '$MATTERMOST_HOOK_URL' $DAILY_CHANNELS"
+        sh """
+          . ${venv}/bin/activate
+          python3 ./agenda.py daily-scrum/planning.yaml '$MATTERMOST_HOOK_URL' $DAILY_CHANNELS
+        """
       }
     }
   }

--- a/jenkins/prepare-virtualenv.sh
+++ b/jenkins/prepare-virtualenv.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -xe -o pipefail
+
+VENV="$1"
+
+python3.7 -m venv --clear "${VENV}"
+source "${VENV}/bin/activate"
+
+pip install -r requirements.txt

--- a/release/Jenkinsfile
+++ b/release/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
           currentBuild.description = "Teambot run for the release"
         }
         checkout scm
-        sh 'pip3 install -r requirements.txt'
+        sh "${WORKSPACE}/jenkins/prepare-virtualenv.sh ${venv}"
       }
     }
 
@@ -27,7 +27,10 @@ pipeline {
         GITHUB_CREDS = credentials('github-jenkins-wazo-bot')
       }
       steps {
-        sh 'python3 ./agenda.py release/planning.yaml "$MATTERMOST_HOOK_URL" release'
+        sh """
+          . ${venv}/bin/activate
+          python3 ./agenda.py release/planning.yaml "$MATTERMOST_HOOK_URL" release
+        """
       }
     }
   }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 github3.py
 pytz
+pyyaml

--- a/sprint-review/Jenkinsfile
+++ b/sprint-review/Jenkinsfile
@@ -1,3 +1,4 @@
+def venv = 'team-bot-venv'
 pipeline {
 
   agent any
@@ -15,7 +16,7 @@ pipeline {
           currentBuild.description = "Teambot run for the sprint review"
         }
         checkout scm
-        sh 'pip3 install -r requirements.txt'
+        sh "${WORKSPACE}/jenkins/prepare-virtualenv.sh ${venv}"
       }
     }
 
@@ -24,7 +25,10 @@ pipeline {
         MATTERMOST_HOOK_URL = credentials("mattermost-teambot-hook")
       }
       steps {
-        sh 'python3 ./agenda.py sprint-review/planning.yaml "$MATTERMOST_HOOK_URL" developpement'
+        sh """
+          . ${venv}/bin/activate
+          python3 ./agenda.py sprint-review/planning.yaml "$MATTERMOST_HOOK_URL" developpement
+        """
       }
     }
   }

--- a/weekly-scrum/Jenkinsfile
+++ b/weekly-scrum/Jenkinsfile
@@ -20,13 +20,16 @@ pipeline {
           currentBuild.description = "Teambot run for the weekly scrum"
         }
         checkout scm
-        sh 'pip3 install -r requirements.txt'
+        sh "${WORKSPACE}/jenkins/prepare-virtualenv.sh ${venv}"
       }
     }
 
     stage ('Run') {
       steps {
-        sh "python3 ./agenda.py weekly-scrum/planning.yaml '$MATTERMOST_HOOK_URL' $WEEKLY_SCRUM_CHANNEL"
+        sh """
+          . ${venv}/bin/activate
+          python3 ./agenda.py weekly-scrum/planning.yaml '$MATTERMOST_HOOK_URL' $WEEKLY_SCRUM_CHANNEL
+        """
       }
     }
   }


### PR DESCRIPTION
Why:

* Don't depend on system / user global python libs
* github3.py installs an incompatible version of cryptography