### PR TITLE
bookworm

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,3 @@
-# See https://pre-commit.com for more information
 repos:
   - repo: https://github.com/PyCQA/flake8
     rev: 6.0.0
@@ -10,19 +9,16 @@ repos:
     rev: 22.12.0
     hooks:
       - id: black
-# Automatically update to modern python (as modern as allowed by your Python version)
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.15.0
     hooks:
       - id: pyupgrade
-        args: [--py39-plus]
-# Automatically sort and format imports (in black compatible way)
+        args: [--py311-plus]
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:
       - id: isort
         args: [--filter-files]
-# See https://pre-commit.com for more information
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 pipeline {
   agent {
-    label 'general'
+    label 'general-debian12-small'
   }
   triggers {
     githubPush()
@@ -22,7 +22,7 @@ pipeline {
     }
     stage('Unit tests') {
       steps {
-        sh 'tox -e py39'
+        sh 'tox -e py311'
       }
     }
   }

--- a/daily-scrum/Jenkinsfile
+++ b/daily-scrum/Jenkinsfile
@@ -5,21 +5,16 @@ def DAILY_CHANNELS = [
 ].join(' ');
 
 pipeline {
-
   agent {
-    label 'general'
+    label 'general-debian12-small'
   }
-
   triggers {
     cron('H 0 * * 1-5')
   }
-
   environment {
     MATTERMOST_HOOK_URL = credentials("mattermost-teambot-hook")
   }
-
   stages {
-
     stage ('Prepare') {
       steps {
         script {
@@ -29,7 +24,6 @@ pipeline {
         sh "${WORKSPACE}/jenkins/prepare-virtualenv.sh ${VENV}"
       }
     }
-
     stage ('Run') {
       environment {
         GITHUB_CREDS = credentials('github-jenkins-wazo-bot')
@@ -42,7 +36,6 @@ pipeline {
       }
     }
   }
-
   post {
     failure {
       mattermostSend color: "danger", message: "Teambot [failed :nuke:](${BUILD_URL}/console)"

--- a/jenkins/prepare-virtualenv.sh
+++ b/jenkins/prepare-virtualenv.sh
@@ -3,7 +3,7 @@ set -xe -o pipefail
 
 VENV="$1"
 
-python3.9 -m venv --clear "${VENV}"
+python3.11 -m venv --clear "${VENV}"
 source "${VENV}/bin/activate"
 
 pip install -r requirements.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,4 +16,4 @@ exclude = [
 
 [tool.isort]
 profile = "black"
-py_version = 39
+py_version = 311

--- a/release/Jenkinsfile
+++ b/release/Jenkinsfile
@@ -1,20 +1,15 @@
 def VENV = 'team-bot-venv'
 pipeline {
-
   agent {
-    label 'general'
+    label 'general-debian12-small'
   }
-
   triggers {
     cron('00 10 * * 1-2')
   }
-
   environment {
     MATTERMOST_HOOK_URL = credentials("mattermost-teambot-hook")
   }
-
   stages {
-
     stage ('Prepare') {
       steps {
         script {
@@ -24,7 +19,6 @@ pipeline {
         sh "${WORKSPACE}/jenkins/prepare-virtualenv.sh ${VENV}"
       }
     }
-
     stage ('Run') {
       environment {
         GITHUB_CREDS = credentials('github-jenkins-wazo-bot')
@@ -37,7 +31,6 @@ pipeline {
       }
     }
   }
-
   post {
     failure {
       mattermostSend color: "danger", message: "Teambot [failed :nuke:](${BUILD_URL}/console)"

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
-env_list = py39, linters
+env_list = py311, linters
 no_package = true
 
 [testenv]
-base_python = python3.9
+base_python = python3.11
 commands =
     pytest test_agenda.py
 deps =
@@ -11,7 +11,6 @@ deps =
     -rtest-requirements.txt
 
 [testenv:linters]
-base_python = python3.10
 skip_install = true
 deps = pre-commit
 commands = pre-commit run --all-files

--- a/weekly-scrum/Jenkinsfile
+++ b/weekly-scrum/Jenkinsfile
@@ -2,21 +2,16 @@ def VENV = 'team-bot-venv'
 def WEEKLY_SCRUM_CHANNEL = 'dev-weekly-scrum';
 
 pipeline {
-
   agent {
-    label 'general'
+    label 'general-debian12-small'
   }
-
   triggers {
     cron('H 0 * * 3')
   }
-
   environment {
     MATTERMOST_HOOK_URL = credentials("mattermost-teambot-hook")
   }
-
   stages {
-
     stage ('Prepare') {
       steps {
         script {
@@ -26,7 +21,6 @@ pipeline {
         sh "${WORKSPACE}/jenkins/prepare-virtualenv.sh ${VENV}"
       }
     }
-
     stage ('Run') {
       steps {
         sh """
@@ -36,7 +30,6 @@ pipeline {
       }
     }
   }
-
   post {
     failure {
       mattermostSend color: "danger", message: "Teambot [failed :nuke:](${BUILD_URL}/console)"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Upgrade CI and tooling to Python 3.11, switch Jenkins to a Debian 12 agent, and align pre-commit/isort/tox configs.
> 
> - **CI**:
>   - **Jenkins**: Change agent to `general-debian12-small` and run unit tests with `tox -e py311` in `Jenkinsfile`.
>   - **Virtualenv**: Use `python3.11` in `jenkins/prepare-virtualenv.sh`.
> - **Tooling**:
>   - **tox**: Set `env_list = py311, linters` and `base_python = python3.11` in `tox.ini`.
>   - **pre-commit**: Update `pyupgrade` to `--py311-plus` in `.pre-commit-config.yaml`.
>   - **isort**: Set `py_version = 311` in `pyproject.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14d519d9448937e4363d42f7b413f7482eea8f1a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->